### PR TITLE
First version of polymorphic housenumber relations

### DIFF
--- a/ban/commands/__init__.py
+++ b/ban/commands/__init__.py
@@ -156,16 +156,24 @@ class Command:
         self.parser.set_defaults(**kwargs)
 
     def report(self, name, item, level):
-        if name not in self._reports:
-            self._reports[name] = []
-        self._reports[name].append((item, level))
+        verbosity = config.get('VERBOSE')
+        if verbosity:
+            if name not in self._reports:
+                self._reports[name] = []
+            self._reports[name].append((item, level))
+        else:
+            # Only track totals.
+            if name not in self._reports:
+                self._reports[name] = 0
+            self._reports[name] += 1
 
     def reporting(self):
         if self._reports:
             sys.stdout.write('\n# Reports:')
             for name, items in self._reports.items():
-                sys.stdout.write('\n- {}: {}'.format(name, len(items)))
                 verbosity = config.get('VERBOSE')
+                total = len(items) if verbosity else items
+                sys.stdout.write('\n- {}: {}'.format(name, total))
                 if verbosity:
                     for item, level in items:
                         if verbosity >= level:

--- a/ban/commands/db.py
+++ b/ban/commands/db.py
@@ -6,11 +6,10 @@ from ban.core.versioning import Diff, Version, IdentifierRedirect
 from . import helpers
 
 models = [Version, Diff, IdentifierRedirect, amodels.User, amodels.Client,
-          amodels.Grant, amodels.Session, amodels.Token, cmodels.PostCode,
-          cmodels.Municipality, cmodels.District,
-          cmodels.Municipality.postcodes.get_through_model(),
+          amodels.Grant, amodels.Session, amodels.Token, cmodels.Municipality,
+          cmodels.Proxy, cmodels.PostCode, cmodels.District,
           cmodels.Street, cmodels.Locality, cmodels.HouseNumber,
-          cmodels.HouseNumber.districts.get_through_model(),
+          cmodels.HouseNumber.ancestors.get_through_model(),
           cmodels.Position]
 
 

--- a/ban/commands/helpers.py
+++ b/ban/commands/helpers.py
@@ -97,22 +97,25 @@ class Bar:
 
 def batch(func, iterable, chunksize=1000, total=None):
     bar = Bar(total=total)
-    workers = int(config.get('WORKERS', os.cpu_count()))
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        count = 0
-        chunk = []
-        for item in iterable:
-            if not item:
-                continue
-            chunk.append(item)
-            count += 1
-            if count % 10000 == 0:
-                for r in executor.map(func, chunk):
-                    bar()
-                chunk = []
-        if chunk:
+
+    def distribute(chunk):
+        with ThreadPoolExecutor(max_workers=workers) as executor:
             for r in executor.map(func, chunk):
                 bar()
+
+    workers = int(config.get('WORKERS', os.cpu_count()))
+    count = 0
+    chunk = []
+    for item in iterable:
+        if not item:
+            continue
+        chunk.append(item)
+        count += 1
+        if count % 10000 == 0:
+            distribute(chunk)
+            chunk = []
+    if chunk:
+        distribute(chunk)
 
 
 def prompt(text, default=None, confirmation=False, coerce=None, hidden=False):

--- a/ban/commands/ignsna.py
+++ b/ban/commands/ignsna.py
@@ -16,7 +16,7 @@ def ignsna(path, **kwargs):
             hsw4aaaa.ai)"""
 
     with Path(path).joinpath('hsp7aaaa.ai').open() as f:
-        batch(process_postcode, f, max_value=file_len(f))
+        batch(process_postcode, f, total=file_len(f))
 
 
 @session

--- a/ban/commands/ignsna.py
+++ b/ban/commands/ignsna.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import peewee
-
 from ban.commands import command, report
 from ban.core.models import Municipality, PostCode
 from .helpers import session, batch, nodiff, file_len
@@ -31,12 +29,8 @@ def process_postcode(line):
         municipality = Municipality.get(Municipality.insee == insee)
     except Municipality.DoesNotExist:
         return report('Municipality Not Existing', insee, report.WARNING)
-    postcode, created = PostCode.get_or_create(code=code, version=1)
+    postcode, created = PostCode.get_or_create(code=code,
+                                               municipality=municipality,
+                                               defaults={'version': 1})
     if created:
         report('PostCode Added', postcode, report.NOTICE)
-    try:
-        postcode.municipalities.add(municipality)
-    except peewee.IntegrityError:
-        report('Association Already Exists', postcode, report.WARNING)
-    else:
-        report('Association Added', postcode, report.NOTICE)

--- a/ban/commands/importer.py
+++ b/ban/commands/importer.py
@@ -21,7 +21,7 @@ def municipalities(path, update=False, departement=None, **kwargs):
     else:
         # We can't read it twice (for counting the len), let's load it for now.
         rows = list(rows)
-    helpers.batch(add_municipality, rows, max_value=len(rows))
+    helpers.batch(add_municipality, rows, total=len(rows))
 
 
 @helpers.session

--- a/ban/commands/oldban.py
+++ b/ban/commands/oldban.py
@@ -44,7 +44,6 @@ def process_row(metadata):
         name=name,
         fantoir=fantoir,
         municipality=municipality.id,
-        ign=id,
         version=1,
     )
     validator = klass.validator(**data)

--- a/ban/commands/oldban.py
+++ b/ban/commands/oldban.py
@@ -62,8 +62,7 @@ def add_housenumber(parent, id, metadata):
     number, *ordinal = id.split(' ')
     ordinal = ordinal[0] if ordinal else ''
     center = [metadata['lon'], metadata['lat']]
-    data = dict(number=number, ordinal=ordinal, version=1)
-    data[parent.__class__.__name__.lower()] = parent.id
+    data = dict(number=number, ordinal=ordinal, version=1, parent=parent.id)
     validator = HouseNumber.validator(**data)
 
     if not validator.errors:

--- a/ban/commands/oldban.py
+++ b/ban/commands/oldban.py
@@ -14,9 +14,10 @@ __namespace__ = 'import'
 def oldban(path, **kwargs):
     """Import from BAN json stream files from
     http://bano.openstreetmap.fr/BAN_odbl/"""
-    max_value = sum(1 for line in iter_file(path))
+    total = sum(1 for line in iter_file(path))
+    print('Done computing file size')
     rows = iter_file(path, formatter=json.loads)
-    batch(process_row, rows, chunksize=100, max_value=max_value)
+    batch(process_row, rows, chunksize=100, total=total)
 
 
 @session

--- a/ban/commands/oldban.py
+++ b/ban/commands/oldban.py
@@ -96,9 +96,8 @@ def add_cea(row):
     laposte = row.get('HEXACLE_1')
     if laposte == 'NR':
         return report('Missing CEA', ign, report.ERROR)
-    hn = HouseNumber.where(HouseNumber.ign == ign).first()
-    if not hn:
+    query = HouseNumber.update(laposte=laposte).where(HouseNumber.ign == ign)
+    done = query.execute()
+    if not done:
         return report('IGN id not found', ign, report.ERROR)
-    hn.laposte = laposte
-    hn.save()
-    report('Done', str(hn), report.NOTICE)
+    report('Done', ign, report.NOTICE)

--- a/ban/commands/oldban.py
+++ b/ban/commands/oldban.py
@@ -69,9 +69,13 @@ def add_housenumber(parent, id, metadata):
     if not validator.errors:
         housenumber = validator.save()
         validator = Position.validator(center=center, version=1,
+                                       kind=Position.ENTRANCE,
                                        housenumber=housenumber.id)
         if not validator.errors:
             validator.save()
+            report('Position', validator.instance, report.NOTICE)
+        else:
+            report('Position error', validator.errors, report.ERROR)
         report('Housenumber', housenumber, report.NOTICE)
     else:
         report('Housenumber error', validator.errors, report.ERROR)

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -112,9 +112,12 @@ class District(ProxyableModel, NamedModel):
 
 class BaseFantoirModel(ProxyableModel, NamedModel):
     identifiers = ['fantoir']
-    resource_fields = ['name', 'alias', 'fantoir', 'municipality']
+    resource_fields = ['name', 'alias', 'fantoir', 'municipality', 'laposte',
+                       'ign']
 
     fantoir = db.CharField(max_length=9, null=True)
+    laposte = db.CharField(max_length=10, null=True)
+    ign = db.CharField(max_length=24, null=True)
 
     class Meta:
         abstract = True
@@ -139,13 +142,14 @@ class Street(BaseFantoirModel):
 class HouseNumber(Model):
     identifiers = ['cia']
     resource_fields = ['number', 'ordinal', 'parent', 'cia', 'laposte',
-                       'ancestors', 'center']
+                       'ancestors', 'center', 'ign']
 
     number = db.CharField(max_length=16)
     ordinal = db.CharField(max_length=16, null=True)
     parent = db.ProxyField(Proxy)
     cia = db.CharField(max_length=100, null=True)
     laposte = db.CharField(max_length=10, null=True)
+    ign = db.CharField(max_length=24, null=True)
     ancestors = db.ProxiesField(Proxy, related_name='housenumbers')
 
     class Meta:

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -203,6 +203,26 @@ class HouseNumber(Model):
 
 
 class Position(Model):
+
+    POSTAL = 'postal'
+    ENTRANCE = 'entrance'
+    BUILDING = 'building'
+    STAIRCASE = 'staircase'
+    UNIT = 'unit'
+    PARCEL = 'parcel'
+    SEGMENT = 'segment'
+    UTILITY = 'utility'
+    KIND = (
+        (POSTAL, _('postal delivery')),
+        (ENTRANCE, _('entrance')),
+        (BUILDING, _('building')),
+        (STAIRCASE, _('staircase identifier')),
+        (UNIT, _('unit identifier')),
+        (PARCEL, _('parcel')),
+        (SEGMENT, _('road segment')),
+        (UTILITY, _('utility service')),
+    )
+
     resource_fields = ['center', 'source', 'housenumber', 'attributes',
                        'kind', 'comment', 'parent']
 
@@ -210,7 +230,7 @@ class Position(Model):
     housenumber = db.ForeignKeyField(HouseNumber)
     parent = db.ForeignKeyField('self', related_name='children', null=True)
     source = db.CharField(max_length=64, null=True)
-    kind = db.CharField(max_length=64, null=True)
+    kind = db.CharField(max_length=64, choices=KIND)
     attributes = db.HStoreField(null=True)
     comment = peewee.TextField(null=True)
 

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -67,7 +67,8 @@ class Municipality(NamedModel):
 
 class ProxyableModel(Model):
     proxy = db.ForeignKeyField(Proxy, unique=True)
-    municipality = db.ForeignKeyField(Municipality, related_name='%ss')
+    municipality = db.ForeignKeyField(Municipality,
+                                      related_name='{classname}s')
     attributes = db.HStoreField(null=True)
 
     class Meta:
@@ -203,10 +204,11 @@ class HouseNumber(Model):
 
 class Position(Model):
     resource_fields = ['center', 'source', 'housenumber', 'attributes',
-                       'kind', 'comment']
+                       'kind', 'comment', 'parent']
 
     center = db.PointField(verbose_name=_("center"))
     housenumber = db.ForeignKeyField(HouseNumber)
+    parent = db.ForeignKeyField('self', related_name='children', null=True)
     source = db.CharField(max_length=64, null=True)
     kind = db.CharField(max_length=64, null=True)
     attributes = db.HStoreField(null=True)

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -112,12 +112,9 @@ class District(ProxyableModel, NamedModel):
 
 class BaseFantoirModel(ProxyableModel, NamedModel):
     identifiers = ['fantoir']
-    resource_fields = ['name', 'alias', 'fantoir', 'municipality', 'laposte',
-                       'ign']
+    resource_fields = ['name', 'alias', 'fantoir', 'municipality']
 
     fantoir = db.CharField(max_length=9, null=True)
-    laposte = db.CharField(max_length=10, null=True)
-    ign = db.CharField(max_length=24, null=True)
 
     class Meta:
         abstract = True

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -156,6 +156,8 @@ class ResourceModel(db.Model, metaclass=BaseResource):
                 row['maxlength'] = max_length
             if not field.null:
                 row['empty'] = False
+            if getattr(field, 'choices', None):
+                row['allowed'] = [v for v, l in field.choices]
             row.update(cls._meta.resource_schema.get(name, {}))
             schema[name] = row
         return schema

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -54,10 +54,7 @@ class Versioned(db.Model, metaclass=BaseVersioned):
         data = {}
         for name, field in fields.items():
             value = getattr(self, field.name)
-            if isinstance(value, peewee.Model):
-                value = value.id
-            elif isinstance(value, ManyToManyQuery):
-                value = [o.id for o in value]
+            value = field.db_value(value)
             data[field.name] = value
         return data
 

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import json
 
 import peewee
-from playhouse.fields import ManyToManyQuery
 
 from ban import db
 from ban.auth.models import Session
@@ -186,7 +185,7 @@ class Diff(db.Model):
     class Meta:
         validate_backrefs = False
         manager = SelectQuery
-        ordering = ('id', )
+        order_by = ('id', )
 
     def save(self, *args, **kwargs):
         if not self.diff:

--- a/ban/db/fields.py
+++ b/ban/db/fields.py
@@ -80,6 +80,11 @@ class ForeignKeyField(peewee.ForeignKeyField):
             value = self.rel_model.coerce(value).id
         return super().coerce(value)
 
+    def _get_related_name(self):
+        # cf https://github.com/coleifer/peewee/pull/844
+        return (self._related_name or '{classname}_set').format(
+                                        classname=self.model_class._meta.name)
+
 
 class CharField(peewee.CharField):
     schema_type = 'string'

--- a/ban/db/fields.py
+++ b/ban/db/fields.py
@@ -10,7 +10,7 @@ from postgis import Point
 __all__ = ['PointField', 'ForeignKeyField', 'CharField', 'IntegerField',
            'HStoreField', 'UUIDField', 'ArrayField', 'DateTimeField',
            'BooleanField', 'BinaryJSONField', 'PostCodeField',
-           'ManyToManyField', 'PasswordField']
+           'ManyToManyField', 'PasswordField', 'ProxiesField', 'ProxyField']
 
 
 lonlat_pattern = re.compile('^[\[\(]{1}(?P<lon>-?\d{,3}(:?\.\d*)?), ?(?P<lat>-?\d{,3}(\.\d*)?)[\]\)]{1}$')  # noqa
@@ -141,7 +141,6 @@ class PostCodeField(CharField):
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 5
-        kwargs['unique'] = True
         super().__init__(*args, **kwargs)
 
     def coerce(self, value):
@@ -149,6 +148,23 @@ class PostCodeField(CharField):
         if not len(value) == 5 or not value.isdigit():
             raise ValueError('Invalid postcode')
         return value
+
+
+class ResourceListQueryResultWrapper(peewee.ModelQueryResultWrapper):
+
+    def process_row(self, row):
+        instance = super().process_row(row)
+        return instance.as_list
+
+
+class ManyToManyQuery(fields.ManyToManyQuery):
+
+    def _get_result_wrapper(self):
+        return getattr(self, '_result_wrapper', None) or ProxiesResultWrapper
+
+    @peewee.returns_clone
+    def as_resource_list(self):
+        self._result_wrapper = ResourceListQueryResultWrapper
 
 
 class ManyToManyField(fields.ManyToManyField):
@@ -162,7 +178,7 @@ class ManyToManyField(fields.ManyToManyField):
         super().__init__(*args, **kwargs)
 
     def coerce(self, value):
-        if not isinstance(value, (tuple, list)):
+        if not isinstance(value, (tuple, list, peewee.SelectQuery)):
             value = [value]
         # https://github.com/coleifer/peewee/pull/795
         value = [self.rel_model.get(self.rel_model.id == item)
@@ -175,6 +191,98 @@ class ManyToManyField(fields.ManyToManyField):
         # https://github.com/coleifer/peewee/issues/794
         model_class._meta.fields[name] = self
         super().add_to_class(model_class, name)
+
+
+class ProxiesResultWrapper(peewee.ModelQueryResultWrapper):
+
+    def process_row(self, row):
+        instance = super().process_row(row)
+        # TODO find a way to make the relation asymetric
+        return getattr(instance, 'real', instance)
+
+
+class ProxiesQuery(ManyToManyQuery):
+
+    def add(self, value, clear_existing=False):
+        if not isinstance(value, (list, tuple, peewee.SelectQuery)):
+            value = [value]
+        value = [item.proxy for item in value]
+        super().add(value, clear_existing)
+
+    def remove(self, value):
+        if not isinstance(value, (list, tuple)):
+            value = [value]
+        value = [item.proxy for item in value]
+        super().remove(value)
+
+
+class ProxiesFieldDescriptor(fields.ManyToManyFieldDescriptor):
+
+    def __get__(self, instance, instance_type=None):
+        if instance is not None:
+            # See https://github.com/coleifer/peewee/issues/838
+            return (ProxiesQuery(instance, self, self.rel_model)
+                    .select()
+                    .join(self.through_model)
+                    .join(self.model_class)
+                    .where(self.src_fk == instance))
+        return self.field
+
+
+class ProxiesField(ManyToManyField):
+
+    def _get_descriptor(self):
+        return ProxiesFieldDescriptor(self)
+
+    def coerce_one(self, value):
+        if isinstance(value, int):
+            value = self.rel_model.get(self.rel_model.id == value)
+        if isinstance(value, self.rel_model):
+            value = value.real
+        return value
+
+    def coerce(self, value):
+        if not isinstance(value, (tuple, list, peewee.SelectQuery)):
+            value = [value]
+        return [self.coerce_one(item) for item in value]
+
+
+class ProxyRelationDescriptor(peewee.RelationDescriptor):
+
+    def __get__(self, instance, instance_type=None):
+        value = super().__get__(instance, instance_type)
+        if instance is not None:
+            return value.real
+        return value
+
+    def __set__(self, instance, value):
+        if (isinstance(value, peewee.Model)
+                and not isinstance(value, self.rel_model)):
+            value = value.proxy
+        super().__set__(instance, value)
+
+
+class ProxyField(ForeignKeyField):
+
+    def _get_descriptor(self):
+        return ProxyRelationDescriptor(self, self.rel_model)
+
+    def coerce(self, value):
+        if not isinstance(value, (int, str)):
+            if not isinstance(value, self.rel_model):
+                value = value.proxy
+            value = value._get_pk_value()
+        else:
+            value = int(value)
+        return value
+
+    def db_value(self, value):
+        value = self.coerce(value)
+        return super().db_value(value)
+
+    def python_value(self, value):
+        value = super().python_value(value)
+        return value.real
 
 
 class PasswordField(PWDField):

--- a/ban/tests/factories.py
+++ b/ban/tests/factories.py
@@ -73,13 +73,6 @@ class BaseFactory(BaseTestModel):
         abstract = True
 
 
-class PostCodeFactory(BaseFactory):
-    code = FuzzyInteger(10000, 97000)
-
-    class Meta:
-        model = models.PostCode
-
-
 class MunicipalityFactory(BaseFactory):
     name = "Montbrun-Bocage"
     insee = FuzzyAttribute(lambda: str(Random().randint(10000, 97000)))
@@ -87,6 +80,14 @@ class MunicipalityFactory(BaseFactory):
 
     class Meta:
         model = models.Municipality
+
+
+class PostCodeFactory(BaseFactory):
+    code = FuzzyInteger(10000, 97000)
+    municipality = factory.SubFactory(MunicipalityFactory)
+
+    class Meta:
+        model = models.PostCode
 
 
 class DistrictFactory(BaseFactory):
@@ -118,15 +119,14 @@ class StreetFactory(BaseFactory):
 class HouseNumberFactory(BaseFactory):
     number = "18"
     ordinal = "bis"
-    street = factory.SubFactory(StreetFactory)
+    parent = factory.SubFactory(StreetFactory)
 
     @factory.post_generation
-    def districts(self, create, extracted, **kwargs):
+    def ancestors(self, create, extracted, **kwargs):
         if not create:
             return
-
         if extracted:
-            self.districts.add(extracted)
+            self.ancestors.add(extracted)
 
     class Meta:
         model = models.HouseNumber

--- a/ban/tests/factories.py
+++ b/ban/tests/factories.py
@@ -135,6 +135,7 @@ class HouseNumberFactory(BaseFactory):
 class PositionFactory(BaseFactory):
     center = (-1.1111, 48.8888)
     housenumber = factory.SubFactory(HouseNumberFactory)
+    kind = models.Position.ENTRANCE
 
     class Meta:
         model = models.Position

--- a/ban/tests/http/test_diff.py
+++ b/ban/tests/http/test_diff.py
@@ -14,7 +14,7 @@ def test_diff_endpoint(client):
     housenumber.ordinal = "ter"
     housenumber.increment_version()
     housenumber.save()
-    street = housenumber.street
+    street = housenumber.parent
     old_street_name = street.name
     street.name = "Rue des Musiciens"
     street.increment_version()

--- a/ban/tests/http/test_municipality.py
+++ b/ban/tests/http/test_municipality.py
@@ -17,9 +17,8 @@ def test_get_municipality(get, url):
 
 
 def test_get_municipality_with_postcodes(get, url):
-    postcode = PostCodeFactory(code="33000")
     municipality = MunicipalityFactory(name="Cabour")
-    municipality.postcodes.add(postcode)
+    PostCodeFactory(code="33000", municipality=municipality)
     uri = url('municipality-resource', identifier=municipality.id)
     resp = get(uri)
     assert resp.status == falcon.HTTP_200
@@ -144,36 +143,6 @@ def test_cannot_duplicate_municipality(client, url):
     assert resp.status == falcon.HTTP_422
     assert resp.json['errors']['insee']
     assert '12345' in resp.json['errors']['insee']
-
-
-@authorize
-def test_create_municipality_with_postcodes(client, url):
-    postcode = PostCodeFactory(code="09350")
-    data = {
-        "name": "Fornex",
-        "insee": "12345",
-        "siren": '123456789',
-        "postcodes": postcode.id
-    }
-    resp = client.post(url('municipality'), data)
-    assert resp.status == falcon.HTTP_201
-    municipality = models.Municipality.first()
-    assert postcode in municipality.postcodes
-
-
-@authorize
-def test_patch_municipality_with_postcodes(client, url):
-    postcode = PostCodeFactory(code="09350")
-    municipality = MunicipalityFactory()
-    data = {
-        "version": 2,
-        "postcodes": postcode.id
-    }
-    uri = url('municipality-resource', identifier=municipality.id)
-    resp = client.post(uri, data)
-    assert resp.status == falcon.HTTP_200
-    municipality = models.Municipality.first()
-    assert postcode in municipality.postcodes
 
 
 @authorize

--- a/ban/tests/http/test_position.py
+++ b/ban/tests/http/test_position.py
@@ -14,6 +14,7 @@ def test_create_position(client):
     url = '/position'
     data = {
         "center": "(3, 4)",
+        "kind": models.Position.ENTRANCE,
         "housenumber": housenumber.id,
     }
     resp = client.post(url, data)
@@ -25,12 +26,40 @@ def test_create_position(client):
 
 
 @authorize
+def test_cannot_create_position_without_kind(client):
+    housenumber = HouseNumberFactory(number="22")
+    assert not models.Position.select().count()
+    url = '/position'
+    data = {
+        "center": "(3, 4)",
+        "housenumber": housenumber.id,
+    }
+    resp = client.post(url, data)
+    assert resp.status == falcon.HTTP_422
+
+
+@authorize
+def test_cannot_create_position_without_invalid_kind(client):
+    housenumber = HouseNumberFactory(number="22")
+    assert not models.Position.select().count()
+    url = '/position'
+    data = {
+        "center": "(3, 4)",
+        "kind": "ENTRANCE",
+        "housenumber": housenumber.id,
+    }
+    resp = client.post(url, data)
+    assert resp.status == falcon.HTTP_422
+
+
+@authorize
 def test_create_position_with_housenumber_cia(client):
     housenumber = HouseNumberFactory(number="22")
     assert not models.Position.select().count()
     url = '/position'
     data = {
         "center": "(3, 4)",
+        "kind": models.Position.ENTRANCE,
         "housenumber": 'cia:{}'.format(housenumber.cia),
     }
     resp = client.post(url, data)
@@ -45,6 +74,7 @@ def test_create_position_with_bad_housenumber_cia_is_422(client):
     url = '/position'
     data = {
         "center": "(3, 4)",
+        "kind": models.Position.ENTRANCE,
         "housenumber": 'cia:{}'.format('xxx'),
     }
     resp = client.post(url, data)
@@ -59,6 +89,7 @@ def test_replace_position(client, url):
     data = {
         "version": 2,
         "center": (3, 4),
+        "kind": models.Position.ENTRANCE,
         "housenumber": position.housenumber.id
     }
     resp = client.put(uri, body=json.dumps(data))
@@ -77,6 +108,7 @@ def test_replace_position_with_housenumber_cia(client, url):
     data = {
         "version": 2,
         "center": (3, 4),
+        "kind": models.Position.ENTRANCE,
         "housenumber": 'cia:{}'.format(position.housenumber.cia)
     }
     resp = client.put(uri, body=json.dumps(data))
@@ -92,6 +124,7 @@ def test_replace_position_with_existing_version_fails(client, url):
     data = {
         "version": 1,
         "center": (3, 4),
+        "kind": models.Position.ENTRANCE,
         "housenumber": position.housenumber.id
     }
     resp = client.put(uri, body=json.dumps(data))
@@ -110,6 +143,7 @@ def test_replace_position_with_non_incremental_version_fails(client, url):
     data = {
         "version": 18,
         "center": (3, 4),
+        "kind": models.Position.ENTRANCE,
         "housenumber": position.housenumber.id
     }
     resp = client.put(uri, body=json.dumps(data))

--- a/ban/tests/http/test_postcode.py
+++ b/ban/tests/http/test_postcode.py
@@ -1,7 +1,7 @@
 import falcon
 from ban.core import models
 
-from ..factories import PostCodeFactory
+from ..factories import PostCodeFactory, MunicipalityFactory
 from .utils import authorize
 
 
@@ -23,9 +23,11 @@ def test_get_postcode_with_code(get, url):
 
 @authorize
 def test_create_postcode(client, url):
+    municipality = MunicipalityFactory()
     assert not models.PostCode.select().count()
     data = {
-        "code": "09350"
+        "code": "09350",
+        "municipality": municipality.id
     }
     resp = client.post(url('postcode'), data)
     assert resp.status == falcon.HTTP_201

--- a/ban/tests/http/test_street.py
+++ b/ban/tests/http/test_street.py
@@ -25,9 +25,9 @@ def test_get_street_with_fantoir(get, url):
 
 def test_get_street_housenumbers(get, url):
     street = StreetFactory()
-    hn1 = HouseNumberFactory(number="1", street=street)
-    hn2 = HouseNumberFactory(number="2", street=street)
-    hn3 = HouseNumberFactory(number="3", street=street)
+    hn1 = HouseNumberFactory(number="1", parent=street)
+    hn2 = HouseNumberFactory(number="2", parent=street)
+    hn3 = HouseNumberFactory(number="3", parent=street)
     resp = get(url('street-housenumbers', identifier=street.id))
     assert resp.json['total'] == 3
     assert resp.json['collection'][0] == hn1.as_list
@@ -172,7 +172,7 @@ def test_cannot_delete_street_if_not_authorized(client, url):
 @authorize
 def test_cannot_delete_street_if_linked_to_housenumber(client, url):
     street = StreetFactory()
-    HouseNumberFactory(street=street)
+    HouseNumberFactory(parent=street)
     uri = url('street-resource', identifier=street.id)
     resp = client.delete(uri)
     assert resp.status == falcon.HTTP_409

--- a/ban/tests/test_commands.py
+++ b/ban/tests/test_commands.py
@@ -71,7 +71,7 @@ def test_truncate_should_not_ask_for_confirm_in_force_mode(monkeypatch):
 def test_export_resources():
     mun = factories.MunicipalityFactory()
     street = factories.StreetFactory(municipality=mun)
-    hn = factories.HouseNumberFactory(street=street)
+    hn = factories.HouseNumberFactory(parent=street)
     factories.PositionFactory(housenumber=hn)
     path = Path(__file__).parent / 'data/export.sjson'
     resources(path)
@@ -92,6 +92,5 @@ def test_import_ignsna(staff):
     factories.MunicipalityFactory(insee='61403')
     pc_path = Path(__file__).parent / 'data/ignsna/'
     ignsna(str(pc_path))
-    post_codes = models.PostCode.select()
-    assert len(post_codes) == 1
-    assert len(post_codes[0].municipalities) == 2
+    postcodes = models.PostCode.select()
+    assert len(postcodes) == 2

--- a/ban/tests/test_managers.py
+++ b/ban/tests/test_managers.py
@@ -13,7 +13,7 @@ def test_street_as_resource():
     assert list(models.Street.select().as_resource()) == [street.as_resource]
 
 
-def test_municipality_street_as_resource():
+def test_municipality_streets_as_resource():
     municipality = MunicipalityFactory()
     street = StreetFactory(municipality=municipality)
-    assert list(municipality.street_set.as_resource()) == [street.as_resource]
+    assert list(municipality.streets.as_resource()) == [street.as_resource]

--- a/ban/tests/test_models.py
+++ b/ban/tests/test_models.py
@@ -292,6 +292,13 @@ def test_position_is_versioned():
     assert version2.housenumber == housenumber
 
 
+def test_position_children():
+    housenumber = HouseNumberFactory()
+    parent = PositionFactory(housenumber=housenumber)
+    child = PositionFactory(housenumber=housenumber, parent=parent)
+    assert child in parent.children
+
+
 def test_position_attributes():
     position = PositionFactory(attributes={'foo': 'bar'})
     assert position.attributes['foo'] == 'bar'

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -110,29 +110,39 @@ def test_invalid_point_should_raise_an_error(session):
 
 
 def test_can_create_postcode(session):
-    validator = models.PostCode.validator(code="31310")
+    municipality = MunicipalityFactory(insee='12345')
+    validator = models.PostCode.validator(code="31310",
+                                          municipality=municipality)
     postcode = validator.save()
     assert postcode.code == "31310"
 
 
 def test_can_create_postcode_with_integer(session):
-    validator = models.PostCode.validator(code=31310)
+    municipality = MunicipalityFactory(insee='12345')
+    validator = models.PostCode.validator(code=31310,
+                                          municipality=municipality)
     postcode = validator.save()
     assert postcode.code == "31310"
 
 
 def test_cannot_create_postcode_with_code_shorter_than_5_chars(session):
-    validator = models.PostCode.validator(code="3131")
+    municipality = MunicipalityFactory(insee='12345')
+    validator = models.PostCode.validator(code="3131",
+                                          municipality=municipality)
     assert 'code' in validator.errors
 
 
 def test_cannot_create_postcode_with_code_bigger_than_5_chars(session):
-    validator = models.PostCode.validator(code="313100")
+    municipality = MunicipalityFactory(insee='12345')
+    validator = models.PostCode.validator(code="313100",
+                                          municipality=municipality)
     assert 'code' in validator.errors
 
 
 def test_cannot_create_postcode_with_code_non_digit(session):
-    validator = models.PostCode.validator(code="2A000")
+    municipality = MunicipalityFactory(insee='12345')
+    validator = models.PostCode.validator(code="2A000",
+                                          municipality=municipality)
     assert 'code' in validator.errors
 
 
@@ -179,7 +189,7 @@ def test_can_create_street_with_municipality_old_insee(session):
 
 def test_can_create_housenumber(session):
     street = StreetFactory()
-    validator = models.HouseNumber.validator(street=street, number='11')
+    validator = models.HouseNumber.validator(parent=street, number='11')
     assert not validator.errors
     housenumber = validator.save()
     assert housenumber.number == '11'
@@ -188,21 +198,21 @@ def test_can_create_housenumber(session):
 def test_can_create_housenumber_with_district(session):
     district = DistrictFactory()
     street = StreetFactory()
-    validator = models.HouseNumber.validator(street=street, number='11',
-                                             districts=[district])
+    validator = models.HouseNumber.validator(parent=street, number='11',
+                                             ancestors=[district])
     assert not validator.errors
     housenumber = validator.save()
-    assert district in housenumber.districts
+    assert district in housenumber.ancestors
 
 
 def test_can_create_housenumber_with_district_ids(session):
     district = DistrictFactory()
     street = StreetFactory()
-    validator = models.HouseNumber.validator(street=street, number='11',
-                                             districts=[district.id])
+    validator = models.HouseNumber.validator(parent=street, number='11',
+                                             ancestors=[district.id])
     assert not validator.errors
     housenumber = validator.save()
-    assert district in housenumber.districts
+    assert district in housenumber.ancestors
 
 
 def test_can_update_housenumber_district(session):
@@ -211,7 +221,7 @@ def test_can_update_housenumber_district(session):
     validator = models.HouseNumber.validator(instance=housenumber,
                                              update=True,
                                              version=2,
-                                             districts=[district])
+                                             ancestors=[district])
     assert not validator.errors
     housenumber = validator.save()
-    assert district in housenumber.districts
+    assert district in housenumber.ancestors

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -102,6 +102,16 @@ def test_can_update_position(session):
     assert position.version == 2
 
 
+def test_can_create_position_with_parent(session):
+    housenumber = HouseNumberFactory()
+    parent = PositionFactory(housenumber=housenumber)
+    validator = models.Position.validator(housenumber=housenumber,
+                                          parent=parent, center=(1, 2))
+    assert not validator.errors
+    position = validator.save()
+    assert position.parent == parent
+
+
 def test_invalid_point_should_raise_an_error(session):
     housenumber = HouseNumberFactory()
     validator = models.Position.validator(housenumber=housenumber,

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -83,6 +83,7 @@ def test_can_create_municipality_with_alias(session):
 def test_can_create_position(session):
     housenumber = HouseNumberFactory()
     validator = models.Position.validator(housenumber=housenumber,
+                                          kind=models.Position.ENTRANCE,
                                           center=(1, 2))
     assert not validator.errors
     position = validator.save()
@@ -92,7 +93,7 @@ def test_can_create_position(session):
 
 def test_can_update_position(session):
     position = PositionFactory(center=(1, 2))
-    validator = models.Position.validator(instance=position,
+    validator = models.Position.validator(instance=position, update=True,
                                           housenumber=position.housenumber,
                                           center=(3, 4), version=2)
     assert not validator.errors
@@ -106,10 +107,18 @@ def test_can_create_position_with_parent(session):
     housenumber = HouseNumberFactory()
     parent = PositionFactory(housenumber=housenumber)
     validator = models.Position.validator(housenumber=housenumber,
+                                          kind=models.Position.ENTRANCE,
                                           parent=parent, center=(1, 2))
     assert not validator.errors
     position = validator.save()
     assert position.parent == parent
+
+
+def test_cannot_create_position_without_kind(session):
+    housenumber = HouseNumberFactory()
+    validator = models.Position.validator(housenumber=housenumber,
+                                          center=(1, 2))
+    assert validator.errors
 
 
 def test_invalid_point_should_raise_an_error(session):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ progressbar2==3.6.0
 psycopg2==2.6.1
 git+https://github.com/yohanboniface/falcon-oauth
 psycopg-postgis
+progressist


### PR DESCRIPTION
Voici une première implémentation du modèle discuté lors de notre point lundi.

### Quelques détails:
- Street, Locality, District et Postcode peut être indistinctement associés à Housenumber, via un modèle Proxy (chacun a une FK qui pointe sur Proxy)
- Street, Locality, Disctric et Postcode n'ont pas d'autoincrement et "héritent" de l'id du proxy 
- Housenumbers a deux relations sur Proxy: un `parent` qui est une FK simple et un `ancestors`, une M2M *(voir point plus bas pour une discussion spécifique)*
- en l'état PostCode a une relation unique (et obligatoire) vers Municipality, ce qui veut dire que, en l'état, quand un postcode s'étant sur plusieurs communes il y aura plusieurs rows (une par commune): si j'ai bien compris, c'est au final ce qu'on veut puise que le libellé d'acheminement sera différent
- globalement le côté "transparent" du proxy fonctionne, mais je suis pas ultra satisfait de l'implémentation actuelle, faudra que j'y repasse un peu si on continue sur cette voie
- question philosophique: je me demande si on vraiment besoin d'une relation si ouverte: au final, par exemple, on sait qu'on voudra jamais deux objets Street associés au même housenumber, or en l'état on ne pourra proprement se prémunir contre un tel cas
- avoir Proxy empêche d'utiliser des identifiant secondaires en relations (par exemple passer "fantoir:12345" pour ajouter une rue à un housenumber)
- le CEA est laissé sur Housenumber, partant du principe qu'on accepterait de dupliquer les fameux 53 cas sur 26 millions
- je pense qu'on peut fusionner Locality et District, en autorisant le NULL pour fantoir (ce qu'on devra faire quoi qu'il en soit), ou éventuellement en redescendant la clé dans le hstore `attributes`.

### Sur le choix entre M2M et FK+M2M:
Concernant la relation Housenumber et parents, on a deux options:
- ou bien simplement une m2m ordonnée, et c'est la première de ces m2m qui est le parent principal (et qui doit d'une manière ou d'une autre être obligatoire)
- ou bien une FK qui définit le parent (obligatoire) et une m2m pour toutes les relations optionnelles

Le premier cas pose deux problèmes ennuyeux:
- il est difficile de s'assurer de façon certaine qu'un housenumber ait toujours au moins une relation (bien sûr le python peut faire tout son possible, mais il n'est pas possible d'avoir de contrainte en base de données, sauf à avoir des triggers); c'est d'autant plus délicat à contrôler au moment de la suppression d'un objet Street ou autre (cet objet est-il associé à un housenumber dont il serait le seul parent?).
- il est impossible d'éviter les doublons: aucune contrainte en base ne nous permet d'empêcher que deux housenumber "2 bis" soient associés à la "rue des Vignes".

Le deuxième cas aussi:
- pas possible d'empêcher des doublons entre les deux relations, par exemple d'avoir une street en tant que `parent` ET dans `ancestors`
- ça fait deux relations à requêter pour remonter la relation, par exemple trouver tous les housenumbers d'un objet Street

Dans les deux cas il est difficile d'empêcher d'avoir deux objets Street liés à un même housenumber tout en autorisant plusieurs District ou plusieurs Postcode.

cc @christopheprudent @cquest and all pour discussion.