### PR TITLE
Add BAN id (cf #82)

### DIFF
--- a/ban/auth/models.py
+++ b/ban/auth/models.py
@@ -154,5 +154,5 @@ class Token(db.Model):
             "client": Client.first(Client.client_id == data['client_id'])
         }
         session = Session.create(**session_data)  # get or create?
-        data['session'] = session.id
+        data['session'] = session.pk
         return Token.create(**data)

--- a/ban/commands/auth.py
+++ b/ban/commands/auth.py
@@ -11,7 +11,7 @@ def dummytoken(**kwargs):
     """Create a dummy token for dev."""
     session = context.get('session')
     Token.delete().where(Token.access_token == 'token').execute()
-    Token.create(session=session.id, access_token="token", expires_in=3600*24)
+    Token.create(session=session.pk, access_token="token", expires_in=3600*24)
     report('Created token', 'token', report.NOTICE)
 
 

--- a/ban/commands/oldban.py
+++ b/ban/commands/oldban.py
@@ -62,7 +62,7 @@ def process_row(metadata):
     data = dict(
         name=name,
         fantoir=fantoir,
-        municipality=municipality.id,
+        municipality=municipality.pk,
         version=1,
     )
     validator = klass.validator(**data)
@@ -83,7 +83,7 @@ def add_housenumber(parent, id, metadata, postcode):
     ordinal = ordinal[0] if ordinal else ''
     center = [metadata['lon'], metadata['lat']]
     ign = metadata.get('id')
-    data = dict(number=number, ordinal=ordinal, version=1, parent=parent.id,
+    data = dict(number=number, ordinal=ordinal, version=1, parent=parent.pk,
                 ign=ign)
     if postcode:
         data['ancestors'] = [postcode]
@@ -94,7 +94,7 @@ def add_housenumber(parent, id, metadata, postcode):
         housenumber = validator.save()
         validator = Position.validator(center=center, version=1,
                                        kind=Position.ENTRANCE,
-                                       housenumber=housenumber.id)
+                                       housenumber=housenumber.pk)
         if not validator.errors:
             validator.save()
             report('Position', validator.instance, report.NOTICE)

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -1,3 +1,5 @@
+import uuid
+
 import peewee
 from cerberus import ValidationError, Validator, errors
 
@@ -23,7 +25,7 @@ class ResourceValidator(Validator):
         attr = getattr(self.model, field)
         qs = qs.where(attr == value)
         if self.instance:
-            qs = qs.where(self.model.id != self.instance.id)
+            qs = qs.where(self.model.pk != self.instance.pk)
         if qs.exists():
             self._error(field, 'Duplicate value for {}: {}'.format(field,
                                                                    value))
@@ -128,10 +130,21 @@ class ResourceModel(db.Model, metaclass=BaseResource):
     resource_fields = ['id']
     identifiers = []
 
+    id = db.CharField(max_length=50, unique=True, null=False)
+
     class Meta:
         abstract = True
-        resource_schema = {}
+        resource_schema = {'id': {'required': False}}
         manager = SelectQuery
+
+    @classmethod
+    def make_id(cls):
+        return 'ban-{}-{}'.format(cls.__name__.lower(), uuid.uuid4().hex)
+
+    def save(self, *args, **kwargs):
+        if not self.id:
+            self.id = self.make_id()
+        return super().save(*args, **kwargs)
 
     @classmethod
     def build_resource_schema(cls):
@@ -190,21 +203,21 @@ class ResourceModel(db.Model, metaclass=BaseResource):
 
     def as_relation_field(self, name):
         value = getattr(self, name)
-        return getattr(value, 'id', value)
+        return getattr(value, 'pk', value)
 
     def as_list_field(self, name):
         value = getattr(self, '{}_resource'.format(name), getattr(self, name))
-        return getattr(value, 'id', value)
+        return getattr(value, 'pk', value)
 
     @classmethod
     def coerce(cls, id, identifier=None):
         if not identifier:
-            identifier = 'id'
+            identifier = 'id'  # BAN id by default.
             if isinstance(id, str):
                 *extra, id = id.split(':')
                 if extra:
                     identifier = extra[0]
-                if identifier not in cls.identifiers + ['id']:
+                if identifier not in cls.identifiers + ['id', 'pk']:
                     raise cls.DoesNotExist("Invalid identifier {}".format(
                                                                 identifier))
         try:

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -37,7 +37,7 @@ class Versioned(db.Model, metaclass=BaseVersioned):
     class Meta:
         abstract = True
         validate_backrefs = False
-        unique_together = ('id', 'version')
+        unique_together = ('pk', 'version')
 
     @classmethod
     def get(cls, *query, **kwargs):
@@ -66,7 +66,7 @@ class Versioned(db.Model, metaclass=BaseVersioned):
             old = self.load_version(self.version - 1)
         new = Version.create(
             model_name=self.__class__.__name__,
-            model_id=self.id,
+            model_pk=self.pk,
             sequential=self.version,
             data=self.serialize()
         )
@@ -77,7 +77,7 @@ class Versioned(db.Model, metaclass=BaseVersioned):
     def versions(self):
         return Version.select().where(
             Version.model_name == self.__class__.__name__,
-            Version.model_id == self.id)
+            Version.model_pk == self.pk)
 
     def load_version(self, id):
         return self.versions.where(Version.sequential == id).first()
@@ -93,9 +93,9 @@ class Versioned(db.Model, metaclass=BaseVersioned):
         self._locked_version = value
 
     def lock_version(self):
-        if not self.id:
+        if not self.pk:
             self.version = 1
-        self._locked_version = self.version if self.id else 0
+        self._locked_version = self.version if self.pk else 0
 
     def increment_version(self):
         self.version = self.version + 1
@@ -143,7 +143,7 @@ class SelectQuery(db.SelectQuery):
 
 class Version(db.Model):
     model_name = db.CharField(max_length=64)
-    model_id = db.IntegerField()
+    model_pk = db.IntegerField()
     sequential = db.IntegerField()
     data = db.BinaryJSONField()
 
@@ -152,7 +152,7 @@ class Version(db.Model):
 
     def __repr__(self):
         return '<Version {} of {}({})>'.format(self.sequential,
-                                               self.model_name, self.model_id)
+                                               self.model_name, self.model_pk)
 
     @property
     def as_resource(self):
@@ -167,7 +167,7 @@ class Version(db.Model):
 
     @property
     def diff(self):
-        return Diff.first(Diff.new == self.id)
+        return Diff.first(Diff.new == self.pk)
 
 
 class Diff(db.Model):
@@ -185,11 +185,11 @@ class Diff(db.Model):
     class Meta:
         validate_backrefs = False
         manager = SelectQuery
-        order_by = ('id', )
+        order_by = ('pk', )
 
     def save(self, *args, **kwargs):
         if not self.diff:
-            meta = set(['id', 'created_by', 'modified_by', 'created_at',
+            meta = set(['pk', 'id', 'created_by', 'modified_by', 'created_at',
                         'modified_at', 'version'])
             old = self.old.as_resource if self.old else {}
             new = self.new.as_resource if self.new else {}
@@ -210,12 +210,12 @@ class Diff(db.Model):
     def as_resource(self):
         version = self.new or self.old
         return {
-            'increment': self.id,
+            'increment': self.pk,
             'old': self.old.as_resource if self.old else None,
             'new': self.new.as_resource if self.new else None,
             'diff': self.diff,
             'resource': version.model_name.lower(),
-            'resource_id': version.model_id,
+            'resource_pk': version.model_pk,
             'created_at': self.created_at
         }
 

--- a/ban/db/model.py
+++ b/ban/db/model.py
@@ -15,9 +15,14 @@ class SelectQuery(peewee.SelectQuery):
 
 class Model(peewee.Model):
 
+    # id is reserved for BAN external id, but lets be consistent and use the
+    # same primary key name all over the models.
+    pk = peewee.PrimaryKeyField()
+
     class Meta:
         database = default
         manager = SelectQuery
+        order_by = ['pk']
 
     # TODO find a way not to override the peewee.Model select classmethod.
     @classmethod

--- a/ban/http/diff.py
+++ b/ban/http/diff.py
@@ -16,7 +16,7 @@ class Diff(BaseCollection):
         qs = versioning.Diff.select()
         increment = req.get_param_as_int('increment')
         if increment:
-            qs = qs.where(versioning.Diff.id > increment)
+            qs = qs.where(versioning.Diff.pk > increment)
         self.collection(req, resp, qs.as_resource())
 
 

--- a/ban/http/resources.py
+++ b/ban/http/resources.py
@@ -191,8 +191,8 @@ class Housenumber(VersionnedResource):
         if bbox:
             qs = (qs.join(models.Position)
                     .where(models.Position.center.in_bbox(**bbox))
-                    .group_by(models.HouseNumber.id)
-                    .order_by(models.HouseNumber.id))
+                    .group_by(models.HouseNumber.pk)
+                    .order_by(models.HouseNumber.pk))
         return qs
 
     @app.endpoint('/{identifier}/positions')

--- a/ban/tests/http/test_diff.py
+++ b/ban/tests/http/test_diff.py
@@ -29,11 +29,14 @@ def test_diff_endpoint(client):
     street_create_diff = diffs[1]
     assert street_create_diff['increment'] == diffs[0]['increment'] + 1
     assert street_create_diff['old'] == None
+    assert street_create_diff['new']['pk'] == street.pk
     assert street_create_diff['new']['id'] == street.id
-    assert street_create_diff['resource_id'] == street.id
+    assert street_create_diff['resource_pk'] == street.pk
     street_update_diff = diffs[-1]
     assert street_update_diff['old']['id'] == street.id
+    assert street_update_diff['old']['pk'] == street.pk
     assert street_update_diff['new']['id'] == street.id
+    assert street_update_diff['new']['pk'] == street.pk
     assert street_update_diff['diff']['name'] == {
         "old": old_street_name,
         "new": "Rue des Musiciens"

--- a/ban/tests/http/test_street.py
+++ b/ban/tests/http/test_street.py
@@ -23,6 +23,12 @@ def test_get_street_with_fantoir(get, url):
     assert resp.json['name'] == "Rue des Boulets"
 
 
+def test_get_street_with_pk(get, url):
+    street = StreetFactory(name="Rue des Boulets")
+    resp = get(url('street-resource', id=street.pk, identifier="pk"))
+    assert resp.json['name'] == "Rue des Boulets"
+
+
 def test_get_street_housenumbers(get, url):
     street = StreetFactory()
     hn1 = HouseNumberFactory(number="1", parent=street)

--- a/ban/tests/test_validators.py
+++ b/ban/tests/test_validators.py
@@ -224,11 +224,11 @@ def test_can_create_housenumber_with_district(session):
     assert district in housenumber.ancestors
 
 
-def test_can_create_housenumber_with_district_ids(session):
+def test_can_create_housenumber_with_district_pks(session):
     district = DistrictFactory()
     street = StreetFactory()
     validator = models.HouseNumber.validator(parent=street, number='11',
-                                             ancestors=[district.id])
+                                             ancestors=[district.pk])
     assert not validator.errors
     housenumber = validator.save()
     assert district in housenumber.ancestors


### PR DESCRIPTION
Quelques précisions sur la PR:
- la clé primaire de la BDD est renommée `pk` (comme "primary key", convention souvent utilisée, par exemple dans Django)
- une colonne `id` est ajoutée, contenant un identifiant ban généré lors du premier save
- c'est l'`id` et non la `pk` qui est considéré l'identifier par défaut (donc passé dans l'URL), mais on peut toujours utiliser la clé primaire au besoin qui reste un identifier valide, en passant donc comme toujours `pk:22` par exemple
- l'id BAN est construit de la sorte `ban-{resource}-{uuid}`, par exemple: `ban-municipality-df30edbcc934413ab61f82368c97802b`. C'est ce qui a été défini lors de l'openlab dédié.

cf #82